### PR TITLE
🔧 *chore(build): alterar branch de push para dev*

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - dev
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the build workflow configuration to trigger on pushes to the `dev` branch instead of the `main` branch.

* Workflow trigger update:
  * [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L6-R6): Changed the build workflow to run on pushes to the `dev` branch rather than the `main` branch.